### PR TITLE
Non empty addok autocomplete parameter enable autocomplete

### DIFF
--- a/test/wrappers/addok_test.rb
+++ b/test/wrappers/addok_test.rb
@@ -96,4 +96,13 @@ class Wrappers::AddokTest < Minitest::Test
     assert v.include? 'addok'
   end
 
+  def test_no_autocomplete
+    rg = GeocoderWrapper::ADDOK_FRA
+    result = rg.geocode({city: '33000 Bordeaux', country: 'FR'}, limit = 1)
+    g = result[:features][0][:properties][:geocoding]
+    assert_equal 'Bordeaux', g[:city]
+    assert_equal 'city', g[:type]
+    assert_equal nil, g[:street]
+  end
+
 end if ENV['ADDOK_API']

--- a/wrappers/addok.rb
+++ b/wrappers/addok.rb
@@ -142,7 +142,7 @@ module Wrappers
       if !json
         p = {
           limit: limit,
-          autocomplete: complete ? 1 : 0,
+          autocomplete: complete ? 1 : '',
           lat: params['lat'],
           lon: params['lng'],
           type: (params[:type] if ['house', 'street'].include?(params[:type]))


### PR DESCRIPTION
`/0.1/geocode?country=fr&city=33000%20bordeaux&type=locality&api_key=demo` return street at first result while we are asking only a city.

```json
{
  "type": "FeatureCollection",
  "geocoding": {
    "version": "draft#namespace#score",
    "licence": "ODbL",
    "attribution": "BANO",
    "query": "33000 bordeaux "
  },
  "features": [
    {
      "properties": {
        "geocoding": {
          "geocoder_version": "Wrapper:1.1.1 - addok:1.1.0-rc1.2",
          "score": 0.9653490909090908,
          "type": "street",
          "label": "Rue Lecocq 33000 Bordeaux",
          "name": "Rue Lecocq",
          "street": "Rue Lecocq",
          "postcode": "33000",
          "city": "Bordeaux",
          "country": "France",
          "id": "33063_5320"
        }
      },
```

On standard geocoding to addok wrapper the autocomplete is always on as non empty value enable it.

```json
{
	"type": "FeatureCollection",
	"geocoding": {
		"version": "draft#namespace#score",
		"licence": "ODbL",
		"attribution": "BANO",
		"query": "33000 bordeaux "
	},
	"features": [{
		"properties": {
			"geocoding": {
				"geocoder_version": "Wrapper:1.1.0 - addok:1.1.0-rc1.2",
				"score": 0.960630909090909,
				"type": "city",
				"label": "33000 Bordeaux",
				"name": "Bordeaux",
				"postcode": "33000",
				"city": "Bordeaux",
				"country": "France",
				"id": "33063"
			}
		},
		"type": "Feature",
		"geometry": {
			"coordinates": [-0.587877, 44.851895],
			"type": "Point"
		}
```