### PR TITLE
Allow quotas to become unlimited

### DIFF
--- a/api/v01/api.rb
+++ b/api/v01/api.rb
@@ -97,7 +97,7 @@ module Api
             next unless op.nil? || op == operation
             quota.slice(:daily, :monthly, :yearly).each do |k, v|
               count = redis_count.get(count_base_key(op, k)).to_i
-              raise QuotaExceeded.new("Too many #{k} requests", limit: v, remaining: v - count, reset: k) if count + request_size > v
+              raise QuotaExceeded.new("Too many #{k} requests", limit: v, remaining: v - count, reset: k) if v && count + request_size > v
             end
           end if raise_if_exceed
         end

--- a/config/access.rb
+++ b/config/access.rb
@@ -20,6 +20,7 @@ module GeocoderWrapper
     # params_limit and quota overload values from profile
     'demo' => { profile: :standard },
     'bulk_limit' => { profile: :standard, params_limit: { locations: 2 }, quotas: [{ operation: :complete, daily: 1 }, { monthly: 2 }] },
+    'bulk_nil_quotas' => { profile: :quotas, params_limit: { locations: 2 }, quotas: [{ operation: :complete, daily: nil }] },
     'expired' => { profile: :standard, expire_at: '2000-01-01' }
   }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -63,6 +63,14 @@ module GeocoderWrapper
         geocoder_fallback: DEMO,
         params_limit: PARAMS_LIMIT,
         quotas: QUOTAS, # Only taken into account if REDIS_COUNT
+      },
+      quotas: {
+        geocoders: {
+          fra: ADDOK_FRA,
+        },
+        geocoder_fallback: DEMO,
+        params_limit: PARAMS_LIMIT,
+        quotas: [{ daily: 100000 }], # Only taken into account if REDIS_COUNT
       }
     },
     ruby_geocode: {

--- a/test/api/v01/unitary_test.rb
+++ b/test/api/v01/unitary_test.rb
@@ -148,6 +148,14 @@ class Api::V01::UnitaryTest < Minitest::Test
                    "X-RateLimit-Reset" => Time.now.utc.to_date.next_day.to_time.to_i }, last_response.headers)
   end
 
+  def test_nil_quotas
+    # assert override 10 by nil (unlimited)
+    11.times do
+      patch '/0.1/geocode', {api_key: 'bulk_nil_quotas', query: 'Place Pey Berland, Bordeaux', country: 'demo'}
+      assert last_response.ok?, last_response.body
+    end
+  end
+
   private
 
   def _test_geocode_from_full_text(country)


### PR DESCRIPTION
This PR allows to override the quotas values with nil so it become unlimited overriding default environnement quotas.