### PR TITLE
Align BANO data type to BAN

### DIFF
--- a/initialize.sh
+++ b/initialize.sh
@@ -5,7 +5,7 @@ mkdir -p addresses
 # shellcheck disable=SC1091
 source ./docker/builder/get_bano.sh
 
-docker-compose -p "${PROJECT}" run --rm --entrypoint /bin/bash addok -c "zcat ./addresses/BAN_odbl.sjson.gz | jq -c 'del(.housenumbers[]?.id)' | addok batch"
+docker-compose -p "${PROJECT}" run --rm --entrypoint /bin/bash addok -c "zcat ./addresses/BAN_odbl.sjson.gz | jq -c 'def mapping: {\"city\":\"municipality\",\"town\":\"municipality\",\"village\":\"municipality\",\"place\":\"locality\",\"street\":\"street\"}; . + {type: mapping[.type]}' | jq -c 'del(.housenumbers[]?.id)' | addok batch"
 
 # Patch BAN
 docker-compose -p "${PROJECT}" run --rm --entrypoint /bin/bash addok -c "ls ./addresses/*.json | xargs cat | addok batch"


### PR DESCRIPTION
The object types of the BAN are
```
locality
municipality
street
```

While for BANO it is
```
city
place
street
town
village
```

This plugin which is specific to BAN loses everything that is not `street`
https://github.com/Mapotempo/addok_usage_name_BAN_FR/blob/master/addok_usage_name_BAN_FR/utils.py#L28-L33

BAN object types are also used elsewhere in the Addok configuration.

They are also mapped in geocoder API.

https://github.com/Mapotempo/geocoder-api/blob/dev/wrappers/addok.rb#L186-L194

- city, town, and village are the population-based version of municipality.
- place` is equivalent to `locality`.

I therefore propose to align the BANO type with the BAN type when importing.